### PR TITLE
QA-713: Suggestions and fixes

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -226,49 +226,7 @@ services:
       default:
         aliases: [mender-inventory]
 
-  reporting:
-    build:
-      context: ..
-      dockerfile: ./backend/services/reporting/Dockerfile
-    image: reporting
-    pull_policy: never
-    restart: on-failure:3
-    command: [server, --automigrate]
-    depends_on:
-      - mongo
-    environment:
-      REPORTING_MONGO_URL: mongodb://mongo
-    labels:
-      traefik.enable: "true"
-      traefik.http.services.reporting.loadBalancer.server.port: "8080"
-      traefik.http.routers.reportingDevV1.entrypoints: "websecure"
-      traefik.http.routers.reportingDevV1.middlewares: >-
-        reportingV1-replacepathregex@file,devStack@file
-      traefik.http.routers.reportingDevV1.rule: >-
-        PathPrefix(`/api/devices/v1/reporting`)
-      traefik.http.routers.reportingDevV1.service: reporting
-      traefik.http.routers.reportingMgmtV1.entrypoints: "websecure"
-      traefik.http.routers.reportingMgmtV1.middlewares: >-
-        reportingMgmtV1-replacepathregex@file,mgmtStack@file
-      traefik.http.routers.reportingMgmtV1.rule: >-
-        PathPrefix(`/api/management/v1/reporting`)
-      traefik.http.routers.reportingMgmtV1.service: reporting
-      traefik.http.routers.reportingDev.entrypoints: "websecure"
-      traefik.http.routers.reportingDev.middlewares: "devStack@file"
-      traefik.http.routers.reportingDev.rule: >-
-        PathPrefix(`/api/devices/{version:v[2-9]}/reporting`)
-      traefik.http.routers.reportingDev.service: reporting
-      traefik.http.routers.reportingMgmt.entrypoints: "websecure"
-      traefik.http.routers.reportingMgmt.middlewares: "mgmtStack@file"
-      traefik.http.routers.reportingMgmt.rule: >-
-        PathPrefix(`/api/management/{version:v[2-9]}/reporting`)
-      traefik.http.routers.reportingMgmt.service: reporting
-
-    networks:
-      default:
-        aliases: [mender-reporting]
-
-  mender-iot-manager:
+  iot-manager:
     build:
       context: ..
       dockerfile: ./backend/services/iot-manager/Dockerfile
@@ -343,13 +301,13 @@ services:
     environment:
       WORKFLOWS_MONGO_URL: "mongodb://mongo"
       WORKFLOWS_NATS_URI: "nats://nats"
-      DEPLOYMENTS_ADDR: mender-deployments:8080
-      DEVICEAUTH_ADDR: mender-deviceauth:8080
-      DEVICECONFIG_ADDR: mender-deviceconfig:8080
-      DEVICECONNECT_ADDR: mender-deviceconnect:8080
-      INVENTORY_ADDR: mender-inventory:8080
-      IOT_MANAGER_ADDR: mender-iot-manager:8080
-      USERADM_ADDR: mender-useradm:8080
+      DEPLOYMENTS_ADDR: deployments:8080
+      DEVICEAUTH_ADDR: deviceauth:8080
+      DEVICECONFIG_ADDR: deviceconfig:8080
+      DEVICECONNECT_ADDR: deviceconnect:8080
+      INVENTORY_ADDR: inventory:8080
+      IOT_MANAGER_ADDR: iot-manager:8080
+      USERADM_ADDR: useradm:8080
       WORKFLOWS_SERVER_ADDR: workflows:8080
       WOKRFLOWS_MENDER_URL: https://localhost
       HAVE_DEVICECONFIG: "1"

--- a/overlay/backend/services/deployments/tests/docker-compose.acceptance.yml
+++ b/overlay/backend/services/deployments/tests/docker-compose.acceptance.yml
@@ -20,6 +20,16 @@ services:
     depends_on:
       mock:
         condition: service_healthy
+      s3fs:
+        condition: service_healthy
+      deployments:
+        condition: service_started
+      inventory:
+        condition: service_started
+      traefik:
+        condition: service_started
+      create-artifact-worker:
+        condition: service_started
   deployments:
     build:
       args:

--- a/overlay/backend/services/iot-manager/tests/docker-compose.acceptance.yml
+++ b/overlay/backend/services/iot-manager/tests/docker-compose.acceptance.yml
@@ -7,14 +7,14 @@ services:
       - ../services/iot-manager/docs:/docs
       - "/var/run/docker.sock:/var/run/docker.sock"
     environment:
-      IOT_MANAGER_URL: "http://mender-iot-manager:8080"
+      TEST_HOST: "iot-manager:8080"
       MMOCK_CONTROL_URL: "http://mmock:8081"
     depends_on:
       - mmock
-      - mender-iot-manager
+      - iot-manager
 
   mmock:
-    image: jordimartin/mmock:v3.0.3
+    image: jordimartin/mmock:v3.1.6
     command:
       - "-config-path=/config"
       - "-console-ip=0.0.0.0"
@@ -32,20 +32,24 @@ services:
       default:
         aliases:
           - mmock
-          - deviceauth
-          - workflows
+          - mender-device-auth
+          - mender-workflows-server
           - mock.azure-devices.net
           - iot.region.amazonaws.com
 
-  mender-iot-manager:
+  iot-manager:
     build:
       args:
         - BIN_FILE=backend/tests/bin/iot-manager.test
-    image: mender-iot-manager:test
+    image: iot-manager:test
     environment:
       IOT_MANAGER_AES_ENCRYPTION_KEY: "+mg+KXQM8/7A+uqs1bJzfH0KW9NclMEVRjkmqhfpjDg="
       IOT_MANAGER_DOMAIN_WHITELIST: "*.azure-devices.net mmock"
+      # FIXME: Update mmock `host` in request conditions
+      IOT_MANAGER_DEVICEAUTH_URL: "http://mender-device-auth:8080"
+      IOT_MANAGER_WORKFLOWS_URL: "http://mender-workflows-server:8080"
       GOCOVERDIR: /cover
     user: ${UID:-0}:${GID:-0}
     volumes:
       - ./cover:/cover
+      - "../services/iot-manager/tests/mmock/cert/server.crt:/etc/ssl/certs/ca-certificates.crt"

--- a/overlay/backend/services/workflows/Makefile
+++ b/overlay/backend/services/workflows/Makefile
@@ -27,7 +27,7 @@ build:
 		go build -o $(binfile) $(BUILDFLAGS)
 
 .PHONY: build-test
-build-test: BUILDFLAGS += -cover -installsuffix .test
+build-test: BUILDFLAGS += -cover -installsuffix .test -tags acceptance
 build-test: binfile = $(GIT_ROOT)/backend/tests/bin/$(COMPONENT).test
 build-test: build
 


### PR DESCRIPTION
~~ Deviceauth is still a mystery :male_detective: ~~
 - Turns out deviceauth (open-source) was running with tenantadm configured. Not sure how to fix :thinking: 
~~I cannot run deviceconfig or deviceconnect because of crashing openapi container. :lobster: ~~
 - Fixed it by overriding ulimits in docker run command.
 - Tests pass :heavy_check_mark: 

For the iot-manager fixes to work: https://github.com/mendersoftware/iot-manager/pull/288